### PR TITLE
Small fix for Firebase deploy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
Vite deploys to /dist, not /public